### PR TITLE
Improve console output for demo game

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,14 +2,15 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"pokerDB/pkg/models"
+	"pokerDB/pkg/utils"
 	"time"
 )
 
 func main() {
-	// ...
 	game := models.Game{
 		ID:           uuid.UUID{},
 		TableID:      uuid.UUID{},
@@ -18,15 +19,36 @@ func main() {
 		EndedTime:    time.Time{},
 		PersonCount:  3,
 	}
-	jsonData, _ := json.Marshal(game)
-	println(string(jsonData))
 
-	err := game.Start()
-	if err != nil {
+	jsonData, _ := json.Marshal(game)
+	fmt.Println(string(jsonData))
+
+	if err := game.Start(); err != nil {
 		logrus.Debug("Game start error: ", err)
 		return
 	}
-	jsonData, _ = json.Marshal(game)
-	println(string(jsonData))
+
+	fmt.Println("Game started at", game.StartedTime.Format(time.RFC3339))
+
+	hands := game.DealHands()
+	for i, h := range hands {
+		fmt.Printf("Player %d: %s %s\n", i+1, utils.CardToString(h[0]), utils.CardToString(h[1]))
+	}
+
+	flop := game.Deal(3)
+	fmt.Printf("Flop: %s %s %s\n", utils.CardToString(flop[0]), utils.CardToString(flop[1]), utils.CardToString(flop[2]))
+
+	turn := game.Deal(1)
+	fmt.Printf("Turn: %s\n", utils.CardToString(turn[0]))
+
+	river := game.Deal(1)
+	fmt.Printf("River: %s\n", utils.CardToString(river[0]))
+
+	if err := game.End(); err != nil {
+		logrus.Debug("Game end error: ", err)
+		return
+	}
+
+	fmt.Println("Game ended at", game.EndedTime.Format(time.RFC3339))
 
 }

--- a/go.sum
+++ b/go.sum
@@ -7,11 +7,13 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/models/game.go
+++ b/pkg/models/game.go
@@ -10,12 +10,13 @@ import (
 )
 
 type Game struct {
-	ID           uuid.UUID `json:"id" gorm:"primary_key;type:uuid;default:uuid_generate_v4()"`
-	TableID      uuid.UUID `json:"table_id" gorm:"type:uuid"`
-	CardSequence []int     `json:"card_sequence" gorm:"type:integer[]"`
-	StartedTime  time.Time `json:"started_time" gorm:"type:timestamp"`
-	EndedTime    time.Time `json:"ended_time" gorm:"type:timestamp"`
-	PersonCount  int       `json:"person_count" gorm:"type:integer"`
+	ID            uuid.UUID `json:"id" gorm:"primary_key;type:uuid;default:uuid_generate_v4()"`
+	TableID       uuid.UUID `json:"table_id" gorm:"type:uuid"`
+	CardSequence  []int     `json:"card_sequence" gorm:"type:integer[]"`
+	StartedTime   time.Time `json:"started_time" gorm:"type:timestamp"`
+	EndedTime     time.Time `json:"ended_time" gorm:"type:timestamp"`
+	PersonCount   int       `json:"person_count" gorm:"type:integer"`
+	NextCardIndex int       `json:"-" gorm:"-"`
 }
 
 func NewGame(tableID uuid.UUID, personCount int) *Game {
@@ -61,6 +62,7 @@ func (g *Game) Start() error {
 	rand.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
 	logrus.Info("Shuffled Sequences: ", shuffled)
 	g.CardSequence = shuffled
+	g.NextCardIndex = 0
 	return nil
 }
 
@@ -75,4 +77,31 @@ func (g *Game) End() error {
 	}
 	g.EndedTime = time.Now()
 	return nil
+}
+
+// Deal removes the first count cards from the game's card sequence and returns
+// them. If there are not enough cards remaining, an empty slice is returned.
+// Deal returns the next 'count' cards from the sequence without modifying the
+// underlying deck. The index is advanced so subsequent calls return the next
+// cards in order. If there are not enough cards remaining, an empty slice is
+// returned.
+func (g *Game) Deal(count int) []int {
+	if g.NextCardIndex+count > len(g.CardSequence) {
+		return []int{}
+	}
+	cards := g.CardSequence[g.NextCardIndex : g.NextCardIndex+count]
+	g.NextCardIndex += count
+	return cards
+}
+
+// DealHands deals two cards to each player and returns a slice of hands where
+// each hand contains two cards for one player.
+// DealHands returns a slice of player hands without altering the card
+// sequence, relying on Deal to advance the index.
+func (g *Game) DealHands() [][]int {
+	hands := make([][]int, g.PersonCount)
+	for i := 0; i < g.PersonCount; i++ {
+		hands[i] = g.Deal(2)
+	}
+	return hands
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,1 +1,16 @@
 package utils
+
+var suits = []string{"♠", "♥", "♦", "♣"}
+var ranks = []string{"A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"}
+
+// CardToString converts a card value from 1-52 into a human readable
+// representation like "A♠" or "10♥". If the value is outside this range,
+// "??" is returned.
+func CardToString(card int) string {
+	if card < 1 || card > 52 {
+		return "??"
+	}
+	suit := suits[(card-1)/13]
+	rank := ranks[(card-1)%13]
+	return rank + suit
+}


### PR DESCRIPTION
## Summary
- show card strings with `utils.CardToString`
- add `Deal` and `DealHands` helpers for `Game`
- expand `cmd/main.go` to display a simple game flow
- keep deck intact by tracking next card index

## Testing
- ❌ `bazel test //...` *(fails: could not download Bazel)*
- ✅ `go run ./cmd/main.go`
