### PR TITLE
Refactor game action storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# pokerDB
+
+This repository contains a small poker toolkit written in Go. The project focuses on describing poker games and now includes a basic data layer using GORM to persist games and actions across multiple SQL databases.
+
+## Building and Testing
+
+This project uses Go modules. To run the unit tests:
+
+```bash
+go test ./...
+```
+
+The tests require network access to download dependencies (GORM and database drivers). In completely offline environments they will fail during module download.
+
+## Database Integration
+
+The `storage` package provides a simple wrapper around GORM with support for MySQL, PostgreSQL and SQLite. Configure the `Dialect` and `DSN` fields in `storage.Config` to connect to the desired backend. SQLite can be used for local testing:
+
+```go
+cfg := storage.Config{Dialect: storage.DialectSQLite, DSN: "file:test.db?cache=shared&mode=memory"}
+db, err := storage.NewDB(cfg)
+```
+
+Tables are created automatically using `AutoMigrate`.
+
+## Compact Action Log
+
+Each `Game` stores a slice of encoded strings describing every event. The first
+entry records the game options (blinds, ante, whether run-it-twice or straddle
+are allowed) and the last entry captures final ledger balances. Intermediate
+entries encode player actions such as raise, fold, check, all-in, straddle and
+run-it-twice selections. Example entries:
+
+```
+G:50:100:0:1:0,1692300000         // game start with small blind, big blind,
+                                   // ante, run-it-twice allowed, straddle allowed
+c0ffee00C0,1692300010              // player c0ffee00 checks
+c0ffee01R500,1692300020            // player c0ffee01 raises to 500
+E:c0ffee00=1000:c0ffee01=-1000,1692300100 // final ledger
+```
+
+`Game.ActionStrings()` formats these entries into human readable lines.
+
+## Project Structure
+
+- `cmd/` – example main program
+- `pkg/models/` – data models used by the application
+- `pkg/storage/` – database connection helpers
+- `pkg/rules/` – poker evaluation and game rules
+- `pkg/utils/` – utility helpers
+
+

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,12 @@ module pokerDB
 go 1.20
 
 require (
-	github.com/google/uuid v1.3.0
-	github.com/sirupsen/logrus v1.9.3
+        github.com/google/uuid v1.3.0
+        github.com/sirupsen/logrus v1.9.3
+        gorm.io/driver/mysql v1.4.6
+        gorm.io/driver/postgres v1.5.2
+        gorm.io/driver/sqlite v1.5.2
+        gorm.io/gorm v1.26.0
 )
 
 require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect

--- a/pkg/models/actionlog.go
+++ b/pkg/models/actionlog.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+)
+
+// Compact action codes used in action log entries.
+const (
+	ActionRaise    = "R" // player raises
+	ActionFold     = "F" // player folds
+	ActionCheck    = "C" // player checks
+	ActionAllIn    = "A" // player goes all in
+	ActionStraddle = "S" // player posts a straddle
+	ActionRunTwice = "T" // players choose run it twice/once
+)
+
+// ActionLog stores encoded action strings. It is persisted as JSON
+// in the database so that different SQL backends can store it uniformly.
+type ActionLog []string
+
+// Value implements the driver.Valuer interface so ActionLog can be stored by GORM.
+func (a ActionLog) Value() (driver.Value, error) {
+	b, err := json.Marshal(a)
+	if err != nil {
+		return nil, err
+	}
+	return string(b), nil
+}
+
+// Scan implements the sql.Scanner interface for loading ActionLog from the DB.
+func (a *ActionLog) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case []byte:
+		return json.Unmarshal(v, a)
+	case string:
+		return json.Unmarshal([]byte(v), a)
+	default:
+		return fmt.Errorf("cannot scan %T", value)
+	}
+}

--- a/pkg/models/ledger.go
+++ b/pkg/models/ledger.go
@@ -1,0 +1,11 @@
+package models
+
+import "github.com/google/uuid"
+
+// Ledger stores the final balance of a player after a game.
+type Ledger struct {
+    ID       uuid.UUID `gorm:"type:uuid;default:uuid_generate_v4();primary_key"`
+    GameID   uuid.UUID `gorm:"type:uuid;index"`
+    PlayerID uuid.UUID `gorm:"type:uuid"`
+    Balance  int64
+}

--- a/pkg/storage/db.go
+++ b/pkg/storage/db.go
@@ -1,0 +1,39 @@
+package storage
+
+import (
+    "fmt"
+
+    "gorm.io/driver/mysql"
+    "gorm.io/driver/postgres"
+    "gorm.io/driver/sqlite"
+    "gorm.io/gorm"
+)
+
+// Dialect represents a supported database backend.
+type Dialect string
+
+const (
+    DialectSQLite   Dialect = "sqlite"
+    DialectPostgres Dialect = "postgres"
+    DialectMySQL    Dialect = "mysql"
+)
+
+// Config describes how to connect to a database.
+type Config struct {
+    Dialect Dialect
+    DSN     string
+}
+
+// NewDB creates a *gorm.DB using the provided configuration.
+func NewDB(cfg Config) (*gorm.DB, error) {
+    switch cfg.Dialect {
+    case DialectSQLite:
+        return gorm.Open(sqlite.Open(cfg.DSN), &gorm.Config{})
+    case DialectPostgres:
+        return gorm.Open(postgres.Open(cfg.DSN), &gorm.Config{})
+    case DialectMySQL:
+        return gorm.Open(mysql.Open(cfg.DSN), &gorm.Config{})
+    default:
+        return nil, fmt.Errorf("unsupported dialect %s", cfg.Dialect)
+    }
+}

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"pokerDB/pkg/models"
+)
+
+// TestSQLiteIntegration exercises creating a game and actions using SQLite.
+func TestSQLiteIntegration(t *testing.T) {
+	cfg := Config{Dialect: DialectSQLite, DSN: "file::memory:?cache=shared"}
+	db, err := NewDB(cfg)
+	if err != nil {
+		t.Fatalf("failed to open sqlite: %v", err)
+	}
+
+	if err := db.AutoMigrate(&models.Game{}, &models.Ledger{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	game := models.NewGame(uuid.New(), 2)
+	if err := db.Create(game).Error; err != nil {
+		t.Fatalf("create game: %v", err)
+	}
+	game.AddAction(uuid.New(), models.ActionCheck, 0)
+	if err := db.Model(&game).Update("action_log", game.ActionLog).Error; err != nil {
+		t.Fatalf("update log: %v", err)
+	}
+
+	var loaded models.Game
+	if err := db.First(&loaded, "id = ?", game.ID).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if len(loaded.ActionLog) != 1 {
+		t.Fatalf("expected 1 action got %d", len(loaded.ActionLog))
+	}
+}


### PR DESCRIPTION
## Summary
- compact action log strings stored directly in `Game`
- add `ActionLog` type and remove old `Action` model
- start/end actions are recorded automatically
- update SQLite storage test for new log
- document compact log format in README

## Testing
- `go mod tidy` *(fails: no route to host)*
- `go test ./...` *(fails: missing go.sum entries for GORM packages)*
