### PR TITLE
Handle CGO-disabled sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ go test ./...
 ```
 
 The tests require network access to download dependencies (GORM and database drivers). In completely offline environments they will fail during module download.
+SQLite integration tests rely on CGO for the `go-sqlite3` driver. When `CGO_ENABLED=0` the tests will be automatically skipped.
 
 ## Database Integration
 

--- a/pkg/storage/db_test.go
+++ b/pkg/storage/db_test.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -12,6 +13,9 @@ func TestSQLiteIntegration(t *testing.T) {
 	cfg := Config{Dialect: DialectSQLite, DSN: "file::memory:?cache=shared"}
 	db, err := NewDB(cfg)
 	if err != nil {
+		if strings.Contains(err.Error(), "CGO_ENABLED=0") {
+			t.Skip("sqlite driver requires CGO, skipping")
+		}
 		t.Fatalf("failed to open sqlite: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- skip SQLite integration test when cgo is disabled
- document the skip behaviour in README

## Testing
- `go test ./... -count=1`
- `CGO_ENABLED=0 go test ./pkg/storage -run SQLiteIntegration -count=1 -v`
