### PR TITLE
Add validation for poker action logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ c0ffee01 raise 500 at 2023-08-18T15:00:20Z
 result [c0ffee00=1000 c0ffee01=-1000] at 2023-08-18T15:01:40Z
 ```
 
+## Action Validation
+
+The `validate` package checks recorded actions for consistency. It ensures
+raises satisfy minimum sizing rules and optionally verifies players have
+sufficient chips when calling or raising. Invoke `validate.Validate` with a game
+and an optional map of starting chip counts keyed by the truncated player IDs
+found in the action log.
+
 ## Project Structure
 
 - `cmd/` – example main program
@@ -63,5 +71,6 @@ result [c0ffee00=1000 c0ffee01=-1000] at 2023-08-18T15:01:40Z
 - `pkg/storage/` – database connection helpers
 - `pkg/rules/` – poker evaluation and game rules
 - `pkg/utils/` – utility helpers
+- `pkg/rules/validate/` – action log validation helpers
 
 

--- a/pkg/rules/validate/validator.go
+++ b/pkg/rules/validate/validator.go
@@ -1,0 +1,145 @@
+package validate
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/google/uuid"
+	"pokerDB/pkg/models"
+)
+
+// ValidationError describes a problem found while checking a game's action log.
+type ValidationError struct {
+	Index int    // zero-based index of the entry in ActionLog
+	Entry string // raw action log entry
+	Err   error  // underlying error
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("entry %d %q: %v", e.Index, e.Entry, e.Err)
+}
+
+func shortID(id uuid.UUID) string {
+	s := id.String()
+	if len(s) > 8 {
+		return s[:8]
+	}
+	return s
+}
+
+// Validate checks the recorded actions of a game. The optional stacks map
+// contains the starting chip count for each player, keyed by the truncated
+// player ID used in the action log. When provided, chip amounts are verified
+// against raises and calls.
+func Validate(g *models.Game, stacks map[string]int64) error {
+	if len(g.ActionLog) < 2 {
+		return fmt.Errorf("action log too short")
+	}
+	if !strings.HasPrefix(g.ActionLog[0], "G:") {
+		return fmt.Errorf("missing start entry")
+	}
+	if !strings.HasPrefix(g.ActionLog[len(g.ActionLog)-1], "E:") {
+		return fmt.Errorf("missing end entry")
+	}
+
+	// track current highest bet and minimum raise size
+	currentBet := g.BigBlind
+	lastRaiseDelta := g.BigBlind
+
+	playerBets := make(map[string]int64)
+	if stacks == nil {
+		stacks = make(map[string]int64)
+	}
+
+	for i, entry := range g.ActionLog[1 : len(g.ActionLog)-1] {
+		idx := i + 1
+		parts := strings.SplitN(entry, ",", 2)
+		if len(parts) != 2 {
+			return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("malformed entry")}
+		}
+		body := parts[0]
+		if len(body) < 9 {
+			return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("invalid body")}
+		}
+		pid := body[:8]
+		code := string(body[8])
+		amtStr := body[9:]
+		amount, err := strconv.ParseInt(amtStr, 10, 64)
+		if err != nil {
+			return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("bad amount")}
+		}
+
+		switch code {
+		case models.ActionRaise:
+			if amount <= currentBet {
+				return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("raise below current bet")}
+			}
+			delta := amount - currentBet
+			if delta < lastRaiseDelta {
+				return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("raise too small")}
+			}
+			need := amount - playerBets[pid]
+			if s, ok := stacks[pid]; ok && need > s {
+				return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("insufficient chips to raise")}
+			}
+			if s, ok := stacks[pid]; ok {
+				stacks[pid] = s - need
+			}
+			playerBets[pid] = amount
+			currentBet = amount
+			lastRaiseDelta = delta
+
+		case models.ActionCheck:
+			if currentBet > playerBets[pid] {
+				// call
+				if amount != currentBet {
+					return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("call amount mismatch")}
+				}
+				need := currentBet - playerBets[pid]
+				if s, ok := stacks[pid]; ok && need > s {
+					return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("insufficient chips to call; must all-in")}
+				}
+				if s, ok := stacks[pid]; ok {
+					stacks[pid] = s - need
+				}
+				playerBets[pid] = currentBet
+			} else {
+				if amount != 0 {
+					return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("check amount must be 0")}
+				}
+			}
+
+		case models.ActionAllIn:
+			need := amount - playerBets[pid]
+			if need < 0 {
+				need = 0
+			}
+			if s, ok := stacks[pid]; ok {
+				if need != s {
+					return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("all-in amount must equal remaining stack")}
+				}
+				stacks[pid] = 0
+			}
+			playerBets[pid] += need
+			if amount > currentBet {
+				delta := amount - currentBet
+				if delta < lastRaiseDelta {
+					return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("all-in raise too small")}
+				}
+				currentBet = amount
+				lastRaiseDelta = delta
+			}
+
+		case models.ActionFold:
+			if amount != 0 {
+				return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("fold amount must be 0")}
+			}
+			playerBets[pid] = 0
+
+		default:
+			return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("unknown action %s", code)}
+		}
+	}
+	return nil
+}

--- a/pkg/rules/validate/validator_test.go
+++ b/pkg/rules/validate/validator_test.go
@@ -1,0 +1,78 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"pokerDB/pkg/models"
+)
+
+func TestValidateGameValid(t *testing.T) {
+	g := models.NewGame(uuid.New(), 2)
+	g.SmallBlind = 50
+	g.BigBlind = 100
+	if err := g.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	p1 := uuid.New()
+	p2 := uuid.New()
+	g.AddAction(p1, models.ActionCheck, 0)
+	g.AddAction(p2, models.ActionRaise, 300)
+	g.AddAction(p1, models.ActionFold, 0)
+	if err := g.End(); err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	stacks := map[string]int64{
+		p1.String()[:8]: 1000,
+		p2.String()[:8]: 1000,
+	}
+	if err := Validate(g, stacks); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateGameInvalidRaise(t *testing.T) {
+	g := models.NewGame(uuid.New(), 2)
+	g.SmallBlind = 50
+	g.BigBlind = 100
+	if err := g.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	p1 := uuid.New()
+	p2 := uuid.New()
+	g.AddAction(p1, models.ActionRaise, 200)
+	g.AddAction(p2, models.ActionRaise, 250)
+	if err := g.End(); err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	if err := Validate(g, nil); err == nil {
+		t.Fatalf("expected error")
+	}
+}
+
+func TestValidateGameInsufficientCall(t *testing.T) {
+	g := models.NewGame(uuid.New(), 2)
+	g.SmallBlind = 50
+	g.BigBlind = 100
+	if err := g.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	p1 := uuid.New()
+	p2 := uuid.New()
+	g.AddAction(p1, models.ActionCheck, 0)
+	g.AddAction(p2, models.ActionRaise, 300)
+	g.AddAction(p1, models.ActionCheck, 300)
+	if err := g.End(); err != nil {
+		t.Fatalf("end: %v", err)
+	}
+
+	stacks := map[string]int64{
+		p1.String()[:8]: 200,
+		p2.String()[:8]: 1000,
+	}
+	if err := Validate(g, stacks); err == nil {
+		t.Fatalf("expected error")
+	}
+}


### PR DESCRIPTION
## Summary
- add `validate` package to check action logs for common rule errors
- document the new validation module in the README
- include unit tests describing expected behaviour

## Testing
- `go test ./pkg/rules/validate -run TestValidateGameValid -v` *(fails: interrupt)*
- `CGO_ENABLED=0 go test ./...` *(fails: interrupt)*