### PR TITLE
Add buy-in support and validation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ safe for concurrent use.
 Each `Game` stores a slice of encoded strings describing every event. The first
 entry records the game options (blinds, ante, whether run-it-twice or straddle
 are allowed) and the last entry captures final ledger balances. Intermediate
-entries encode player actions such as raise, fold, check, all-in, straddle and
-run-it-twice selections. Example entries:
+entries encode player actions such as raise, fold, check, all-in, straddle,
+buy-ins and run-it-twice selections. Example entries:
 
 ```
 G:50:100:0:1:0,1692300000         // game start with small blind, big blind,
@@ -73,6 +73,14 @@ c0ffee00 check 0 at 2023-08-18T15:00:10Z
 c0ffee01 raise 500 at 2023-08-18T15:00:20Z
 result [c0ffee00=1000 c0ffee01=-1000] at 2023-08-18T15:01:40Z
 ```
+
+## Buy-In Handling
+
+Games define `MinBuyIn` and `MaxBuyIn` limits. Players must call
+`Game.BuyIn` before the first hand is dealt. Buy-ins are recorded as
+`B` entries in the action log and cannot occur once the game has
+started. Starting the game fails if the number of buy-ins does not
+match `PersonCount` or if any amounts are outside the allowed range.
 
 ## Action Validation
 

--- a/pkg/models/actionlog.go
+++ b/pkg/models/actionlog.go
@@ -14,6 +14,7 @@ const (
 	ActionAllIn    = "A" // player goes all in
 	ActionStraddle = "S" // player posts a straddle
 	ActionRunTwice = "T" // players choose run it twice/once
+	ActionBuyIn    = "B" // player buys chips before start
 )
 
 // ActionWords maps short action codes to fully spelled words used
@@ -25,6 +26,7 @@ var ActionWords = map[string]string{
 	ActionAllIn:    "all-in",
 	ActionStraddle: "straddle",
 	ActionRunTwice: "run-twice",
+	ActionBuyIn:    "buy-in",
 }
 
 // ActionToWord returns a human readable word for the given action

--- a/pkg/models/buyin.go
+++ b/pkg/models/buyin.go
@@ -1,0 +1,39 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+// BuyIn records the starting chip amount a player brings to a game.
+type BuyIn struct {
+	PlayerID uuid.UUID `json:"player_id"`
+	Amount   int64     `json:"amount"`
+}
+
+// BuyInList is a JSON serializable slice of BuyIns.
+type BuyInList []BuyIn
+
+// Value implements driver.Valuer so BuyInList can be persisted by GORM.
+func (b BuyInList) Value() (driver.Value, error) {
+	data, err := json.Marshal(b)
+	if err != nil {
+		return nil, err
+	}
+	return string(data), nil
+}
+
+// Scan implements sql.Scanner for BuyInList.
+func (b *BuyInList) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case []byte:
+		return json.Unmarshal(v, b)
+	case string:
+		return json.Unmarshal([]byte(v), b)
+	default:
+		return fmt.Errorf("cannot scan %T", value)
+	}
+}

--- a/pkg/models/game_strings_test.go
+++ b/pkg/models/game_strings_test.go
@@ -10,24 +10,34 @@ func TestActionStringsReadable(t *testing.T) {
 	g := NewGame(uuid.New(), 2)
 	g.SmallBlind = 50
 	g.BigBlind = 100
+	p1 := uuid.New()
+	p2 := uuid.New()
+	g.MinBuyIn = 100
+	g.MaxBuyIn = 1000
+	if err := g.BuyIn(p1, 200); err != nil {
+		t.Fatalf("buyin1: %v", err)
+	}
+	if err := g.BuyIn(p2, 200); err != nil {
+		t.Fatalf("buyin2: %v", err)
+	}
 	if err := g.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	g.AddAction(uuid.New(), ActionCheck, 0)
-	g.AddAction(uuid.New(), ActionRaise, 200)
+	g.AddAction(p1, ActionCheck, 0)
+	g.AddAction(p2, ActionRaise, 200)
 	if err := g.End(); err != nil {
 		t.Fatalf("end: %v", err)
 	}
 
 	lines := g.ActionStrings()
-	if len(lines) < 3 {
-		t.Fatalf("expected at least 3 lines got %d", len(lines))
+	if len(lines) < 5 {
+		t.Fatalf("expected at least 5 lines got %d", len(lines))
 	}
-	if !containsWord(lines[1], "check") {
-		t.Errorf("expected check action, got %s", lines[1])
+	if !containsWord(lines[3], "check") {
+		t.Errorf("expected check action, got %s", lines[3])
 	}
-	if !containsWord(lines[2], "raise") {
-		t.Errorf("expected raise action, got %s", lines[2])
+	if !containsWord(lines[4], "raise") {
+		t.Errorf("expected raise action, got %s", lines[4])
 	}
 }
 

--- a/pkg/models/game_test.go
+++ b/pkg/models/game_test.go
@@ -12,6 +12,16 @@ func TestGameStartEndErrors(t *testing.T) {
 	}
 
 	g = NewGame(uuid.New(), 2)
+	g.MinBuyIn = 100
+	g.MaxBuyIn = 1000
+	p1 := uuid.New()
+	p2 := uuid.New()
+	if err := g.BuyIn(p1, 200); err != nil {
+		t.Fatalf("buyin1: %v", err)
+	}
+	if err := g.BuyIn(p2, 200); err != nil {
+		t.Fatalf("buyin2: %v", err)
+	}
 	if err := g.Start(); err != nil {
 		t.Fatalf("unexpected start error: %v", err)
 	}
@@ -23,5 +33,33 @@ func TestGameStartEndErrors(t *testing.T) {
 	}
 	if err := g.End(); err == nil {
 		t.Fatal("expected error on second end")
+	}
+}
+
+func TestGameBuyInLogic(t *testing.T) {
+	g := NewGame(uuid.New(), 2)
+	g.MinBuyIn = 100
+	g.MaxBuyIn = 1000
+
+	if err := g.Start(); err == nil {
+		t.Fatal("start should fail without buy-ins")
+	}
+
+	p1 := uuid.New()
+	p2 := uuid.New()
+	if err := g.BuyIn(p1, 50); err == nil {
+		t.Fatal("expected buy-in below min to fail")
+	}
+	if err := g.BuyIn(p1, 200); err != nil {
+		t.Fatalf("buy-in p1: %v", err)
+	}
+	if err := g.BuyIn(p2, 300); err != nil {
+		t.Fatalf("buy-in p2: %v", err)
+	}
+	if err := g.Start(); err != nil {
+		t.Fatalf("start with buy-ins: %v", err)
+	}
+	if err := g.BuyIn(uuid.New(), 200); err == nil {
+		t.Fatal("expected buy-in after start to fail")
 	}
 }

--- a/pkg/rules/validate/validator.go
+++ b/pkg/rules/validate/validator.go
@@ -36,7 +36,15 @@ func Validate(g *models.Game, stacks map[string]int64) error {
 	if len(g.ActionLog) < 2 {
 		return fmt.Errorf("action log too short")
 	}
-	if !strings.HasPrefix(g.ActionLog[0], "G:") {
+
+	startIdx := -1
+	for i, entry := range g.ActionLog {
+		if strings.HasPrefix(entry, "G:") {
+			startIdx = i
+			break
+		}
+	}
+	if startIdx == -1 {
 		return fmt.Errorf("missing start entry")
 	}
 	if !strings.HasPrefix(g.ActionLog[len(g.ActionLog)-1], "E:") {
@@ -52,8 +60,8 @@ func Validate(g *models.Game, stacks map[string]int64) error {
 		stacks = make(map[string]int64)
 	}
 
-	for i, entry := range g.ActionLog[1 : len(g.ActionLog)-1] {
-		idx := i + 1
+	for i, entry := range g.ActionLog[startIdx+1 : len(g.ActionLog)-1] {
+		idx := i + startIdx + 1
 		parts := strings.SplitN(entry, ",", 2)
 		if len(parts) != 2 {
 			return &ValidationError{Index: idx, Entry: entry, Err: fmt.Errorf("malformed entry")}

--- a/pkg/rules/validate/validator_test.go
+++ b/pkg/rules/validate/validator_test.go
@@ -11,12 +11,20 @@ func TestValidateGameValid(t *testing.T) {
 	g := models.NewGame(uuid.New(), 2)
 	g.SmallBlind = 50
 	g.BigBlind = 100
+	g.MinBuyIn = 100
+	g.MaxBuyIn = 1000
+	p1 := uuid.New()
+	p2 := uuid.New()
+	if err := g.BuyIn(p1, 500); err != nil {
+		t.Fatalf("buyin p1: %v", err)
+	}
+	if err := g.BuyIn(p2, 500); err != nil {
+		t.Fatalf("buyin p2: %v", err)
+	}
 	if err := g.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	p1 := uuid.New()
-	p2 := uuid.New()
-	g.AddAction(p1, models.ActionCheck, 0)
+	g.AddAction(p1, models.ActionCheck, 100)
 	g.AddAction(p2, models.ActionRaise, 300)
 	g.AddAction(p1, models.ActionFold, 0)
 	if err := g.End(); err != nil {
@@ -36,11 +44,19 @@ func TestValidateGameInvalidRaise(t *testing.T) {
 	g := models.NewGame(uuid.New(), 2)
 	g.SmallBlind = 50
 	g.BigBlind = 100
+	g.MinBuyIn = 100
+	g.MaxBuyIn = 1000
+	p1 := uuid.New()
+	p2 := uuid.New()
+	if err := g.BuyIn(p1, 500); err != nil {
+		t.Fatalf("buyin p1: %v", err)
+	}
+	if err := g.BuyIn(p2, 500); err != nil {
+		t.Fatalf("buyin p2: %v", err)
+	}
 	if err := g.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	p1 := uuid.New()
-	p2 := uuid.New()
 	g.AddAction(p1, models.ActionRaise, 200)
 	g.AddAction(p2, models.ActionRaise, 250)
 	if err := g.End(); err != nil {
@@ -56,12 +72,20 @@ func TestValidateGameInsufficientCall(t *testing.T) {
 	g := models.NewGame(uuid.New(), 2)
 	g.SmallBlind = 50
 	g.BigBlind = 100
+	g.MinBuyIn = 100
+	g.MaxBuyIn = 1000
+	p1 := uuid.New()
+	p2 := uuid.New()
+	if err := g.BuyIn(p1, 500); err != nil {
+		t.Fatalf("buyin p1: %v", err)
+	}
+	if err := g.BuyIn(p2, 500); err != nil {
+		t.Fatalf("buyin p2: %v", err)
+	}
 	if err := g.Start(); err != nil {
 		t.Fatalf("start: %v", err)
 	}
-	p1 := uuid.New()
-	p2 := uuid.New()
-	g.AddAction(p1, models.ActionCheck, 0)
+	g.AddAction(p1, models.ActionCheck, 100)
 	g.AddAction(p2, models.ActionRaise, 300)
 	g.AddAction(p1, models.ActionCheck, 300)
 	if err := g.End(); err != nil {


### PR DESCRIPTION
## Summary
- handle player buy-ins before a game starts
- add `BuyIn` model and persistable list type
- store buy-in limits in `Game`
- validate start conditions ensure all players bought in
- extend validator to skip pre-game buy-in actions
- update README
- update and add tests

## Testing
- `go test ./...`